### PR TITLE
License for review

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,2 @@
+# Copyright (c) 2022 Copyright holder of the paper Receding Horizon Re-ordering of Multi-Agent Execution Schedules submitted to The IEEE Transactions on Robotics for review.
+# All rights reserved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sadg-controller"
 version = "0.1.0"
 description = "Switchable Action Dependency Graph (SADG) control scheme for MAPF plan re-ordering"
 authors = ["Alex Berndt <berndtae@gmail.com>"]
-license = "MIT"
+license = "Proprietary"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"

--- a/src/sadg_controller/package.xml
+++ b/src/sadg_controller/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="berndtae@gmail.com">Alex Berndt</maintainer>
 
 
-  <license>MIT</license>
+  <license>Proprietary</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>


### PR DESCRIPTION
This text specifies who holds the copyright and states that no rights are given to the reviewers except, implicitly, the right to read and test. We will change this for an Apache-2.0 license when making open source. By starting with an empty repo on [github.com/boschresearch](github.com/boschresearch), the documentation of who holds copyright over what exactly will remain clear.

We should merge this with `main` asap. The ROS2 interface should remain in a separate branch during the review phase. We'll merge the branches only once the code is under Apache-2.0 and hosted on [github.com/boschresearch](github.com/boschresearch) to ensure Alex keeps copyright for everything he wrote, and we keep copyright for what we did.