### PR TITLE
Address logic error in SADG compiler.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -21,6 +21,8 @@
 # Please keep the list sorted.
 
 Alex Berndt <berndtae@gmail.com>
+Niels van Duijkeren <nielsvanduijkeren@gmail.com>
 
 Robert Bosch GmbH
     Niels van Duijkeren <niels.vanduijkeren@de.bosch.com>
+

--- a/sadg_controller/sadg_controller/sadg/compiler.py
+++ b/sadg_controller/sadg_controller/sadg/compiler.py
@@ -103,6 +103,8 @@ def compile_sadg(P: Plan, logger: Logger) -> SADG:  # noqa: C901
                         v_j_l.add_dependency(fwd)
 
                         try:
+                            if k==0:
+                                raise IndexError("k-1 would wrap to -1 in Python")
 
                             v_i_k_minus_1 = vertices_i[k - 1]
                             v_j_l_plus_1 = vertices_j[l + 1]


### PR DESCRIPTION
@alexberndt This should be a fairly straightforward fix for https://github.com/alexberndt/sadg-controller/issues/26. It would be better to not rely on raising index errors I guess. The example seems to work fine after the change.